### PR TITLE
Fix heuristic evalutaion problems

### DIFF
--- a/Space Chat/www/index.html
+++ b/Space Chat/www/index.html
@@ -38,7 +38,7 @@
         Sorry, your browser doesn't support the canvas element.
     </canvas>
     <p id="message">Message</p>
-    <textarea rows="4" cols="50" id="input-text" width='200px' name="test"></textarea>
+    <textarea rows="4" cols="50" id="input-text" style='width:200px;height:1.5em;' name="test"></textarea>
     <div id="footer" style="position:absolute;bottom:0;text-align:center">
         <button id="red-button" class="color-button" style="background-color: #FF0000"></button>
         <button id="blue-button" class="color-button" style="background-color: #0000FF"></button>

--- a/Space Chat/www/js/main.js
+++ b/Space Chat/www/js/main.js
@@ -25,22 +25,32 @@ function handleEnd(evt) {
 }
 
 function touchEnded(x, y) {
-	if (session.mode == Session.Modes.TEXT || session.mode == Session.Modes.NONE) { // Default to text box
+	console.log('touch');
+	// Do text if text is chosen or if there was no recent mode
+	if (session.mode == Session.Modes.TEXT || session.mode == Session.Modes.NONE) {
 		updateCurrentMode(Session.Modes.TEXT);
 
 		var input = $("#input-text");
-		input.css({
-			'position': 'absolute',
-			'left': x+'px',
-			'top': y+'px'
-		});
-		input.show();
-		input.focus();
+		console.log('hi');
+		console.log(input.val());
+		console.log(input.val() == '');
+
+		if (input.val() == '' || input.val() == undefined) {
+			console.log('yo');
+			input.css({
+				'position': 'absolute',
+				'left': x+'px',
+				'top': y+'px'
+			});
+			input.show();
+			input.focus();
+		} else {
+			enteredText(input);
+		}
 	}
 	else if (session.mode == Session.Modes.QUICK_CHAT) {
 		drawText(session.currentSelectedQuickChat.innerHTML, x, y, '30px');
 
-		updateCurrentMode(Session.Modes.NONE);
 		updateCurrentQuickChatIcon();
 	}
 }
@@ -50,8 +60,6 @@ function enteredText(input) {
 
 	input.hide();
 	input.val('');
-
-	updateCurrentMode(Session.Modes.NONE);
 }
 
 function drawText(text, x, y, fontSize) {

--- a/Space Chat/www/js/main.js
+++ b/Space Chat/www/js/main.js
@@ -25,18 +25,13 @@ function handleEnd(evt) {
 }
 
 function touchEnded(x, y) {
-	console.log('touch');
 	// Do text if text is chosen or if there was no recent mode
 	if (session.mode == Session.Modes.TEXT || session.mode == Session.Modes.NONE) {
 		updateCurrentMode(Session.Modes.TEXT);
 
 		var input = $("#input-text");
-		console.log('hi');
-		console.log(input.val());
-		console.log(input.val() == '');
 
 		if (input.val() == '' || input.val() == undefined) {
-			console.log('yo');
 			input.css({
 				'position': 'absolute',
 				'left': x+'px',


### PR DESCRIPTION
When clicking away from a text box, if there's already text in the box, draw the text on the screen. Otherwise if there's no text to draw, move the box.

Also, maintain state, and don't reset the mode to NONE after placing text. This means that the current "tool" will persist, so you can place multiple checkmarks or multiple text boxes.